### PR TITLE
Removing wa appinsights by default from case-event-handler

### DIFF
--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -22,7 +22,7 @@ servicebus:
     environment: "development"
   enabled: true
   resourceGroup: chart-tests-aso-preview-rg
-  sbNamespace: chart-tests
+  sbNamespace: chart-tests-servicebus
   setup:
     topics:
       - name: ccd-case-events

--- a/wa/values.yaml
+++ b/wa/values.yaml
@@ -96,8 +96,6 @@ wa-case-event-handler:
     keyVaults:
       wa:
         secrets:
-          - name: app-insights-connection-string
-            alias: app-insights-connection-string
           - name: s2s-secret-case-event-handler
             alias: S2S_SECRET_CASE_EVENT_HANDLER
           - name: ld-secret


### PR DESCRIPTION
Jira: https://tools.hmcts.net/jira/browse/RWA-2607
Removing appinsights so servicebus resource failure logs in service team PRs do not hit our logs.