### PR TITLE
Abbreviating name

### DIFF
--- a/wa/values.yaml
+++ b/wa/values.yaml
@@ -167,7 +167,7 @@ wa-initiation-batch:
 
 wa-reconfiguration-batch:
   job:
-    releaseNameOverride: "{{ .Release.Name }}-wa-task-batch-reconfiguration"
+    releaseNameOverride: "{{ .Release.Name }}-wa-task-batch-reconfig"
     kind: CronJob
     schedule: "*/5 * * * *"
     aadIdentityName: wa


### PR DESCRIPTION
There is a 53 char limit on names which breaks builds.  This one is used in the workflow-api for instance this: https://build.platform.hmcts.net/view/WA/job/HMCTS_j_to_z/job/wa-workflow-api/job/master/407/execution/node/379/log/

https://tools.hmcts.net/jira/browse/RWA-2766