### PR TITLE
Remove helm-requirements from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,3 @@
 {
-  "enabledManagers": ["helm-requirements"],
-  "helm-requirements":
-    {
-      "enabled": true,
-      "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
-      "aliases": {
-        "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
-      }
-    }
+  "enabledManagers": []
 }

--- a/.github/renovate.json.bak
+++ b/.github/renovate.json.bak
@@ -1,0 +1,11 @@
+{
+  "enabledManagers": ["helm-requirements"],
+  "helm-requirements":
+    {
+      "enabled": true,
+      "fileMatch": ["\\Chart.yaml|requirements.yaml$"],
+      "aliases": {
+        "hmctspublic": "https://hmctspublic.azurecr.io/helm/v1/repo/"
+      }
+    }
+}


### PR DESCRIPTION
This PR removes the deprecated helm-requirements manager which is no longer needed. Please review and merge.